### PR TITLE
[Feature] Add group selector logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,5 +213,3 @@ venv.bak/
 pip-selfcheck.json
 
 # End of https://www.gitignore.io/api/venv,python,pycharm+all
-
-inventory.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ansibleinviewer - Ansible Inventory Viewer 
+# Ansibleinviewer - Ansible Inventory Viewer
 
 ## SSH into all hosts in your inventory with one command.
 
@@ -18,16 +18,32 @@ cd ansibleinviewer
 python3 -m pip install .
 ```
 
-### Usage example:
+### Usage examples:
 
+Connect to all hosts in inventory:
 ```
 source <(ansibleinviewer -i inventory.yml)
+```
+
+Connect to all hosts from group1 and group2:
+```
+source <(ansibleinviewer -i inventory.yml -g 'group1:group2')
+```
+
+Connect to all hosts from group1 except for hosts that are also in group2:
+```
+source <(ansibleinviewer -i inventory.yml -g 'group1:!group2')
+```
+
+Connect to all hosts from inventory except for hosts in group1:
+```
+source <(ansibleinviewer -i inventory.yml -g '!group1')
 ```
 
 #### Possible flags
 
 * `-i`, `--inventory` - Path to ansible inventory
-* `-g`, `--groups` - Inventory groups of hosts to connect to
+* `-g`, `--groups` - Inventory groups of hosts to connect to (multiple groups should be concentrated with *:*. *!* in front of group name means that ansibleinviewer should not connect to hosts form this group)
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ python3 -m pip install .
 ```
 
 ### Usage example:
+
 ```
 source <(ansibleinviewer -i inventory.yml)
 ```
+
+#### Possible flags
+
+* `-i`, `--inventory` - Path to ansible inventory
+* `-g`, `--groups` - Inventory groups of hosts to connect to
 
 ### Authentication
 

--- a/ansibleinviewer/inventoryparser.py
+++ b/ansibleinviewer/inventoryparser.py
@@ -17,7 +17,7 @@ def update_hosts_dict_with_new_hosts(hosts_dict: dict, new_hosts_dict: dict):
 class InventoryParser:
     def __init__(self, inventory_data):
         self.hosts: set = set()
-        self.inventory_data = inventory_data
+        self.inventory_data: dict = inventory_data
         self.parse_inventory(inventory_data)
 
     def truncate_data(self, inventory_data: Iterable, groups: Iterable):

--- a/ansibleinviewer/inventoryparser.py
+++ b/ansibleinviewer/inventoryparser.py
@@ -89,7 +89,6 @@ class InventoryParser:
                     host_list.append(host)
         else:
             host_list = list(self.hosts)
-        limited_hosts = []
         if no_groups and no_groups != []:
             no_hosts = self.truncate_data(self.inventory_data, no_groups)
             host_list = [host for host in host_list if host.hostname not in no_hosts]

--- a/ansibleinviewer/main.py
+++ b/ansibleinviewer/main.py
@@ -40,12 +40,58 @@ def create_tmux_script(hosts: List[Host], vertical_panes) -> str:
     return tmux_script
 
 
+def slice_from_string(string: str):
+    """Parse standard indices string into slice type or integer
+    Slice is returned when range of indices is specified.
+    In case of single index, integer will be returned.
+
+    :param string: String to parse
+    :type string: str
+
+    :return: Slice or Integer with indices
+    :rtype: str or slice
+    """
+    if ':' in string:
+        return slice(*map(lambda x: int(x.strip()) if x.strip() else None, string.split(':')))
+    else:
+        if string.isdigit():
+            return int(string)
+        else:
+            print(f"Error parsing index {string}")
+            exit(1)
+
+
+def parse_inventory_groups(groups):
+    """Parse list of inventory groups passed via CLI
+    Groups with indices like: 3, [3:], [:3] should be parsed into slices
+    that later can be utilizes as list indices on inventory parsing
+
+    :param groups: List of strings with groups
+    :type groups: list
+
+    :return: List with tuples (name of group, slice of group)
+    :rtype: list
+    """
+
+    parsed_groups = []
+    for group in groups:
+        try:
+            open_bracket = group.index('[')
+            close_bracket = group.index(']')
+            parsed_group = (group[:open_bracket],
+                            slice_from_string(group[open_bracket+1:close_bracket]))
+        except ValueError:
+            parsed_group = (group, None)
+        parsed_groups.append(parsed_group)
+    return parsed_groups
+
+
 def parse_arguments():
     description = '''
     ansibleinviewer creates a shell command that sets up tmux layout and starts
     an ssh session for each "sshable" host from the inventory in a separate pane.
-    Tmux available in PATH is required for this to work. 
-    
+    Tmux available in PATH is required for this to work.
+
     Example:
     source <(inviewer -i inventory.yml)
     '''
@@ -57,6 +103,13 @@ def parse_arguments():
         '--inventory',
         required=True,
         help='Path to the ansible inventory file'
+    )
+    parser.add_argument(
+        '-g',
+        '--groups',
+        nargs='+',
+        default=None,
+        help='Groups to connect with'
     )
     parser.add_argument(
         '-v',
@@ -74,7 +127,8 @@ def main():
         exit(1)
     args = parse_arguments()
     inventory_data = load_inventory_file(args.inventory)
-    inventory_parser = InventoryParser(inventory_data)
+    groups = parse_inventory_groups(args.groups)
+    inventory_parser = InventoryParser(inventory_data, groups)
     tmux_script = create_tmux_script(inventory_parser.get_hosts(), args.vertical_panes)
     print(tmux_script)
 

--- a/ansibleinviewer/main.py
+++ b/ansibleinviewer/main.py
@@ -40,7 +40,6 @@ def create_tmux_script(hosts: List[Host], vertical_panes) -> str:
     return tmux_script
 
 
-
 def parse_inventory_groups(args_groups):
     """Parse list of inventory groups passed via CLI
     Groups with indices like: 3, [3:], [:3] should be parsed into slices
@@ -107,7 +106,8 @@ def main():
     inventory_data = load_inventory_file(args.inventory)
     groups, no_groups = parse_inventory_groups(args.groups)
     inventory_parser = InventoryParser(inventory_data)
-    tmux_script = create_tmux_script(inventory_parser.get_hosts(groups, no_groups), args.vertical_panes)
+    tmux_script = create_tmux_script(inventory_parser.get_hosts(groups, no_groups),
+                                     args.vertical_panes)
     print(tmux_script)
 
 

--- a/ansibleinviewer/main.py
+++ b/ansibleinviewer/main.py
@@ -53,6 +53,8 @@ def parse_inventory_groups(args_groups):
                 * groups that should be ommited
     :rtype: list
     """
+    if not args_groups:
+        return None, None
     provided_groups = args_groups.split(':')
     groups = []
     no_groups = []

--- a/ansibleinviewer/main.py
+++ b/ansibleinviewer/main.py
@@ -40,50 +40,29 @@ def create_tmux_script(hosts: List[Host], vertical_panes) -> str:
     return tmux_script
 
 
-def slice_from_string(string: str):
-    """Parse standard indices string into slice type or integer
-    Slice is returned when range of indices is specified.
-    In case of single index, integer will be returned.
 
-    :param string: String to parse
-    :type string: str
-
-    :return: Slice or Integer with indices
-    :rtype: str or slice
-    """
-    if ':' in string:
-        return slice(*map(lambda x: int(x.strip()) if x.strip() else None, string.split(':')))
-    else:
-        if string.isdigit():
-            return int(string)
-        else:
-            print(f"Error parsing index {string}")
-            exit(1)
-
-
-def parse_inventory_groups(groups):
+def parse_inventory_groups(args_groups):
     """Parse list of inventory groups passed via CLI
     Groups with indices like: 3, [3:], [:3] should be parsed into slices
     that later can be utilizes as list indices on inventory parsing
 
-    :param groups: List of strings with groups
-    :type groups: list
+    :param args_groups: List of strings with groups
+    :type args_groups: list
 
-    :return: List with tuples (name of group, slice of group)
+    :return: Two lists of:
+                * groups that should be selected
+                * groups that should be ommited
     :rtype: list
     """
-
-    parsed_groups = []
-    for group in groups:
-        try:
-            open_bracket = group.index('[')
-            close_bracket = group.index(']')
-            parsed_group = (group[:open_bracket],
-                            slice_from_string(group[open_bracket+1:close_bracket]))
-        except ValueError:
-            parsed_group = (group, None)
-        parsed_groups.append(parsed_group)
-    return parsed_groups
+    provided_groups = args_groups.split(':')
+    groups = []
+    no_groups = []
+    for group in provided_groups:
+        if group.startswith('!'):
+            no_groups.append(group[1:])
+        else:
+            groups.append(group)
+    return groups, no_groups
 
 
 def parse_arguments():
@@ -107,7 +86,6 @@ def parse_arguments():
     parser.add_argument(
         '-g',
         '--groups',
-        nargs='+',
         default=None,
         help='Groups to connect with'
     )
@@ -127,9 +105,9 @@ def main():
         exit(1)
     args = parse_arguments()
     inventory_data = load_inventory_file(args.inventory)
-    groups = parse_inventory_groups(args.groups)
-    inventory_parser = InventoryParser(inventory_data, groups)
-    tmux_script = create_tmux_script(inventory_parser.get_hosts(), args.vertical_panes)
+    groups, no_groups = parse_inventory_groups(args.groups)
+    inventory_parser = InventoryParser(inventory_data)
+    tmux_script = create_tmux_script(inventory_parser.get_hosts(groups, no_groups), args.vertical_panes)
     print(tmux_script)
 
 

--- a/ansibleinviewer/tests/files/inventory.yml
+++ b/ansibleinviewer/tests/files/inventory.yml
@@ -1,0 +1,125 @@
+all:
+  vars:
+    varA: 'a'
+    varB: 'b'
+    varC:
+      - 'uno'
+      - 'dos'
+      - 'tres'
+groupA:
+  hosts:
+    10.0.0.5:
+      hostvar: test
+    172.16.0.30:
+      hostvar: test
+    192.168.0.2:
+      hostvar: test2
+groupB:
+  hosts:
+    10.0.0.4:
+      ansible_become: true
+      ansible_host: 10.0.0.4
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+    10.0.0.5:
+      ansible_become: true
+      ansible_host: 10.0.0.5
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ProxyCommand="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ServerAliveInterval=5 -o ServerAliveCountMax=60 -W %h:%p -q root@1.2.3.4"
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+    172.16.0.30:
+      ansible_become: true
+      ansible_host: 172.16.0.30
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+    172.16.0.43:
+      ansible_become: true
+      ansible_host: 172.16.0.43
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ProxyCommand="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ServerAliveInterval=5 -o ServerAliveCountMax=60 -W %h:%p -q root@4.3.2.1"
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+    172.16.0.8:
+      ansible_become: true
+      ansible_host: 172.16.0.8
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+      private_ip: 172.16.0.8
+    192.168.0.2:
+      ansible_become: true
+      ansible_host: 192.168.0.2
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ProxyCommand="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+        -o ServerAliveInterval=5 -o ServerAliveCountMax=60 -W %h:%p -q root@9.8.7.6"
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+    192.168.0.3:
+      ansible_become: true
+      ansible_host: 9.8.7.6
+      ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      ansible_ssh_pass: null
+      ansible_ssh_user: root
+groupC:
+  hosts:
+    172.16.0.43:
+      Cvar: test_c_group
+groupD:
+  hosts:
+    10.0.0.4:
+      peers:
+      - 172.16.0.8
+      - 192.168.0.3
+      myname: Dhost1
+      deploy: true
+      zones: &id001
+      - a
+      - b
+      - c
+      services: []
+    172.16.0.8:
+      peers:
+      - 10.0.0.4
+      - 192.168.0.3
+      myname: Dhost2
+      deploy: true
+      zones: *id001
+      services: []
+    192.168.0.3:
+      peers:
+      - 10.0.0.4
+      - 192.168.0.3
+      myname: Dhost3
+      deploy: true
+      zones: *id001
+      services: []
+groupE:
+  hosts:
+    10.0.0.4:
+      myname: Dhost1
+    172.16.0.8:
+      myname: Dhost2
+    192.168.0.3:
+      myname: Dhost3
+localhost:
+  hosts:
+    localhost:
+      ansible_connection: local
+      ansible_python_interpreter: python
+      config_file: /my/test/config.yml
+      connection: local
+  vars: {}
+groupF:
+  hosts:
+    10.0.0.4: {}
+    10.0.0.5: {}
+    172.16.0.30: {}
+    172.16.0.43: {}
+    172.16.0.8: {}
+    192.168.0.2: {}
+    192.168.0.3: {}

--- a/ansibleinviewer/tests/requirements.txt
+++ b/ansibleinviewer/tests/requirements.txt
@@ -1,3 +1,3 @@
-parameterized==0.7.0
-pytest==5.2.2
+parameterized>=0.7
+pytest>=5.2
 PyYAML>=4.0

--- a/ansibleinviewer/tests/requirements.txt
+++ b/ansibleinviewer/tests/requirements.txt
@@ -1,0 +1,3 @@
+parameterized==0.7.0
+pytest==5.2.2
+PyYAML>=4.0

--- a/ansibleinviewer/tests/test_inventoryparser.py
+++ b/ansibleinviewer/tests/test_inventoryparser.py
@@ -55,15 +55,15 @@ class TestInventoryParser(unittest.TestCase):
         hosts_from_inventory = [host.hostname for host
                                 in self.inventory.get_hosts(no_groups=[group_name])]
         expected_hosts = list(set(self.all_hosts) - set(group_hosts))
-        self.assertListEqual(sorted(hosts_from_inventory), sorted(hosts_from_inventory))
+        self.assertListEqual(sorted(expected_hosts), sorted(hosts_from_inventory))
 
     @parameterized.expand([(['groupA', 'groupC'], [], groupAC_hosts, []),
                            (['groupD'], ['groupE'], groupD_hosts, groupE_hosts),
-                           ([], ['groupD', 'groupC'], [], groupDC_hosts)])
+                           ([], ['groupD', 'groupC'], all_hosts, groupDC_hosts)])
     def test_inventory_parse_mixed_group_hosts(self, group_name, no_group_name,
                                                group_hosts, no_group_hosts):
         hosts_from_inventory = [host.hostname for host
                                 in self.inventory.get_hosts(groups=group_name,
                                                             no_groups=no_group_name)]
         expected_hosts = list(set(group_hosts) - set(no_group_hosts))
-        self.assertListEqual(sorted(hosts_from_inventory), sorted(hosts_from_inventory))
+        self.assertListEqual(sorted(expected_hosts), sorted(hosts_from_inventory))

--- a/ansibleinviewer/tests/test_inventoryparser.py
+++ b/ansibleinviewer/tests/test_inventoryparser.py
@@ -1,0 +1,87 @@
+import os
+from parameterized import parameterized
+import unittest
+import yaml
+
+from ansibleinviewer.inventoryparser import InventoryParser
+
+
+class TestInventoryParser(unittest.TestCase):
+
+    all_hosts = ['10.0.0.4', '10.0.0.5',
+                 '172.16.0.30', '172.16.0.43', '172.16.0.8',
+                 '192.168.0.2', '192.168.0.3']
+    groupA_hosts = ['10.0.0.5', '172.16.0.30', '192.168.0.2']
+    groupB_hosts = all_hosts
+    groupC_hosts = ['172.16.0.43']
+    groupD_hosts = ['10.0.0.4', '172.16.0.8', '192.168.0.3']
+    groupE_hosts = ['10.0.0.4', '172.16.0.8', '192.168.0.3']
+    groupF_hosts = all_hosts
+
+    @staticmethod
+    def load_inventory_file(inventory_path: str):
+        with open(inventory_path) as inventory_file:
+            inventory_data = yaml.safe_load(inventory_file)
+        return inventory_data
+
+    def setUp(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        self.inventory_data = self.load_inventory_file(f'{ dir_path}/files/inventory.yml')
+
+    def test_inventory_parse_all_hosts(self):
+        inventory = InventoryParser(self.inventory_data)
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        self.assertListEqual(hosts_from_inventory, self.all_hosts)
+
+    @parameterized.expand([('groupA', groupA_hosts),
+                           ('groupB', groupB_hosts),
+                           ('groupC', groupC_hosts),
+                           ('groupD', groupD_hosts),
+                           ('groupE', groupE_hosts),
+                           ('groupF', groupF_hosts)])
+    def test_inventory_parse_group_hosts_no_limit(self, group_name, group_hosts):
+        inventory = InventoryParser(self.inventory_data, [(group_name, None)])
+        hosts_from_inventory = [host.hostname for host in inventory.get_hosts()]
+        self.assertListEqual(sorted(hosts_from_inventory), sorted(group_hosts))
+
+    @parameterized.expand([('groupA', groupA_hosts),
+                           ('groupB', groupB_hosts),
+                           ('groupC', groupC_hosts),
+                           ('groupD', groupD_hosts),
+                           ('groupE', groupE_hosts),
+                           ('groupF', groupF_hosts)])
+    def test_inventory_parse_group_hosts_left_side_limit(self, group_name, group_hosts):
+        limit = slice(None, 2, None)
+        inventory = InventoryParser(self.inventory_data, [(group_name, limit)])
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        self.assertListEqual(sorted(hosts_from_inventory), sorted(group_hosts[limit]))
+
+    @parameterized.expand([('groupA', groupA_hosts),
+                           ('groupB', groupB_hosts),
+                           ('groupD', groupD_hosts),
+                           ('groupE', groupE_hosts),
+                           ('groupF', groupF_hosts)])
+    def test_inventory_parse_group_hosts_right_side_limit(self, group_name, group_hosts):
+        limit = slice(2, None, None)
+        inventory = InventoryParser(self.inventory_data, [(group_name, limit)])
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        self.assertListEqual(sorted(hosts_from_inventory), sorted(group_hosts[limit]))
+
+    def test_inventory_parse_2_groups(self):
+        inventory = InventoryParser(self.inventory_data, [('groupA', None), ('groupC', None)])
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        expected_list = self.groupA_hosts + self.groupC_hosts
+        self.assertListEqual(sorted(expected_list), sorted(hosts_from_inventory))
+
+    def test_inventory_parse_2_groups_one_with_limit(self):
+        limit = slice(None, 2, None)
+        inventory = InventoryParser(self.inventory_data, [('groupA', limit), ('groupC', None)])
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        expected_list = self.groupA_hosts[:2] + self.groupC_hosts
+        self.assertListEqual(sorted(expected_list), sorted(hosts_from_inventory))
+
+    def test_inventory_parse_2_groups_both_with_limit(self):
+        inventory = InventoryParser(self.inventory_data, [('groupA', 2), ('groupC', 0)])
+        hosts_from_inventory = sorted([host.hostname for host in inventory.get_hosts()])
+        expected_list = [self.groupA_hosts[2], self.groupC_hosts[0]]
+        self.assertListEqual(sorted(expected_list), sorted(hosts_from_inventory))

--- a/ansibleinviewer/tests/test_main.py
+++ b/ansibleinviewer/tests/test_main.py
@@ -1,0 +1,39 @@
+from parameterized import parameterized
+import unittest
+
+from ansibleinviewer.main import slice_from_string, parse_inventory_groups
+
+
+class TestMain(unittest.TestCase):
+
+    @parameterized.expand([
+        ('3', 3),
+        (':3', slice(None, 3, None)),
+        ('3:', slice(3, None, None)),
+        (':', slice(None, None, None))
+    ])
+    def test_slice_from_string(self, string, expected):
+        self.assertEqual(slice_from_string(string), expected)
+
+    @parameterized.expand([
+        ('', None),
+        ('[3]', 3),
+        ('[:3]', slice(None, 3, None))
+    ])
+    def test_parse_inventory_groups_single_group(self, limit_string, limit):
+        expected = [('test_group', limit)]
+        tested_group_string = [f'test_group{limit_string}']
+        self.assertListEqual(expected, parse_inventory_groups(tested_group_string))
+
+    @parameterized.expand([
+        (['', ''], [None, None]),
+        (['[4]', ''], [4, None]),
+        (['[4:]', ''], [slice(4, None, None), None]),
+        (['[4:]', '[:2]'], [slice(4, None, None), slice(None, 2, None)]),
+        (['[4:]', '[7]'], [slice(4, None, None), 7]),
+    ])
+    def test_parse_inventory_groups_multi_group(self, limit_strings, limits):
+        groups = ['test_group1', 'test_group2']
+        expected = list(zip(groups, limits))
+        groups_to_parse = [f'{group}{limit}' for group, limit in zip(groups, limit_strings)]
+        self.assertListEqual(sorted(expected), sorted(parse_inventory_groups(groups_to_parse)))

--- a/ansibleinviewer/tests/test_main.py
+++ b/ansibleinviewer/tests/test_main.py
@@ -6,6 +6,11 @@ from ansibleinviewer.main import parse_inventory_groups
 
 class TestMain(unittest.TestCase):
 
+    def test_parse_inventory_groups_None(self):
+        groups, no_groups = parse_inventory_groups(None)
+        self.assertEqual(None, groups)
+        self.assertEqual(None, no_groups)
+
     def test_parse_inventory_groups_single_group(self):
         groups, no_groups = parse_inventory_groups('test_group')
         self.assertListEqual(['test_group'], groups)


### PR DESCRIPTION
In this review:
* I added logic for selecting only specific groups from inventory. It works with multiple groups and also with standard indices like: [3], [:3], [3:]. Groups may be specified with `-g` or `--groups` flag So it's possible to connect for example: Only to first 3 hosts from groupA and last host from groupB. (`-g groupA[:3] groupB[-1]). Old logic works the same way - it's still possible to pass only inventory and expect to open all hosts.
* I added unittests for inventoryparser.py and 2 functions that I added to main.py
* I added sample inventory file (under *tests/files/*) - don't worry, I made sure that there's no confidential information inside :) Only mock data.

P.S.
I checked my code with *flake8* with --max-line-length parameter set to 100.