### PR TITLE
Add note to README about alternative to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Connect to all hosts that have AWS provider:
 source <(ansibleconnect -i inventory.yml -vars provider:aws)>
 ```
 
+**NOTE:** In case you don't use bash. You can also use *eval* command, for example:
+```
+eval "$(ansibleconnect -i inventories/inventory.yml)"
+```
+
 #### Possible flags
 
 * `-i`, `--inventory` - Path to ansible inventory


### PR DESCRIPTION
Add note to README where is shown alternative to `source <()` command.
For exmaple ash does not support this format and usage of `eval "$"` is necessary.